### PR TITLE
Fixed erroneous and incorrect file regex

### DIFF
--- a/src/NextCordovaExporter/HtmlParser.php
+++ b/src/NextCordovaExporter/HtmlParser.php
@@ -17,7 +17,7 @@ final class HtmlParser extends LoggerClass
 
         $file = fopen($htmlFilePath, "r");
         $data = fread($file, filesize($htmlFilePath));
-        preg_match_all('/\"\/_next([0-9A-Za-z-_\/]+)\.(js|css|png|jpeg|webp|gif)\"/', $data, $matches);
+        preg_match_all('/\"\/_next(\/[0-9A-Za-z-_])*\/[0-9A-Za-z-_]\.(js|css|png|jpe?g|webp|gif)\"/', $data, $matches);
         $matches = $matches[0];
         foreach($matches as $key => $m)
         {


### PR DESCRIPTION
the current scanning regex also covers locations that should not be:
![image](https://github.com/bariscodefxy/next-cordova-exporter/assets/54374743/17c67be5-3120-4f80-82ca-03506f52e428)
